### PR TITLE
Add Buffered Channel with Goroutine

### DIFF
--- a/client.go
+++ b/client.go
@@ -7,25 +7,37 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sync"
 	"time"
 )
 
 var version = "0.0.9" // This gets changed automatically during the release process
 
+type request struct {
+	ctx  context.Context
+	path string
+	body any
+}
+
 type client struct {
-	token  string
-	host   string
-	hc     *http.Client
+	token string
+	host  string
+	hc    *http.Client
+	async bool
+	q     chan request
+	wg    sync.WaitGroup
 }
 
 // Configuration options for the Vemetric Client.
 type Opts struct {
 	// Required. This is the token of your project. You can find it in the Settings page.
-	Token   string
+	Token string
 	// Host is optional. If not provided, defaults to "https://hub.vemetric.com"
-	Host    string
+	Host string
 	// Default timeout is 3 seconds.
 	Timeout time.Duration
+	// Default is false.
+	Async bool
 }
 
 var (
@@ -48,13 +60,22 @@ func New(o *Opts) (*client, error) {
 		timeout = o.Timeout
 	}
 
-	return &client{
+	c := &client{
 		token: o.Token,
 		host:  host,
 		hc: &http.Client{
 			Timeout: timeout,
 		},
-	}, nil
+		async: o.Async,
+		q:     make(chan request, 1000),
+		wg:    sync.WaitGroup{},
+	}
+
+	c.wg.Add(1)
+
+	go c.worker()
+
+	return c, nil
 }
 
 // Tracks a custom event for the user with the given identifier.
@@ -63,7 +84,16 @@ func (c *client) TrackEvent(ctx context.Context, opts *TrackEventOpts) error {
 		return errors.New("vemetric: event name required")
 	}
 
-	return c.post(ctx, "/e", opts)
+	if !c.async {
+		return c.post(ctx, "/e", opts)
+	}
+
+	select {
+	case c.q <- request{ctx: ctx, path: "/e", body: opts}:
+		return nil
+	default:
+		return errors.New("vemetric: event dropped, queue full")
+	}
 }
 
 // Updates the data of the user with the given identifier.
@@ -72,7 +102,22 @@ func (c *client) UpdateUser(ctx context.Context, opts *UpdateUserOpts) error {
 		return errors.New("vemetric: user identifier required")
 	}
 
-	return c.post(ctx, "/u", opts)
+	if !c.async {
+		return c.post(ctx, "/u", opts)
+	}
+
+	select {
+	case c.q <- request{ctx: ctx, path: "/u", body: opts}:
+		return nil
+	default:
+		return errors.New("vemetric: update dropped, queue full")
+	}
+}
+
+func (c *client) Close() {
+	close(c.q)
+
+	c.wg.Wait()
 }
 
 func (c *client) post(ctx context.Context, path string, body any) error {
@@ -86,7 +131,7 @@ func (c *client) post(ctx context.Context, path string, body any) error {
 	if err != nil {
 		return err
 	}
-	
+
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Token", c.token)
 	httpReq.Header.Set("User-Agent", "vemetric-go/"+version)
@@ -103,4 +148,16 @@ func (c *client) post(ctx context.Context, path string, body any) error {
 		return fmt.Errorf("%w: %s", ErrBadStatus, res.Status)
 	}
 	return nil
+}
+
+func (c *client) worker() {
+	defer c.wg.Done()
+
+	for request := range c.q {
+		ctx, cancel := context.WithTimeout(request.ctx, 3*time.Second)
+
+		_ = c.post(ctx, request.path, request.body)
+
+		cancel()
+	}
 }

--- a/client_test.go
+++ b/client_test.go
@@ -112,8 +112,8 @@ func TestTrackEvent(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "nil options",
-			opts: nil,
+			name:    "nil options",
+			opts:    nil,
 			wantErr: true,
 		},
 		{
@@ -217,8 +217,8 @@ func TestContextCancellation(t *testing.T) {
 	defer server.Close()
 
 	client, err := New(&Opts{
-		Token:   "test-token",
-		Host:    server.URL,
+		Token: "test-token",
+		Host:  server.URL,
 	})
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
@@ -235,4 +235,4 @@ func TestContextCancellation(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error due to cancelled context, got nil")
 	}
-} 
+}


### PR DESCRIPTION
With the current implementation, especially when used within an API request pipeline, the tracking of events adds between 70 and 300ms.

This is not acceptable in most application and can be solved by using a Goroutine to send the metrics while the current thread can just push to a buffered channel.

cc: @dsumer