### PR TITLE
Implement functional option pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea/

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -8,10 +8,11 @@ import (
 )
 
 func main() {
-	client, err := vemetric.New(&vemetric.Opts{
-		Token: "o1rySsGlUtFCyflo",
-		Host: "http://localhost:4004", // Host is optional. If not provided, defaults to "https://hub.vemetric.com"
-	})
+	client, err := vemetric.New(
+		"o1rySsGlUtFCyflo",
+		// Host is optional. If not provided, defaults to "https://hub.vemetric.com"
+		vemetric.WithHost("http://localhost:4004"),
+	)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -20,7 +21,7 @@ func main() {
 
 	// Track an event
 	err = client.TrackEvent(ctx, &vemetric.TrackEventOpts{
-		EventName: "SignupCompleted",
+		EventName:      "SignupCompleted",
 		UserIdentifier: "dmmIrnzUzVMJD03tjCiHXTEEgX6xIPJm",
 		EventData: map[string]any{
 			"plan": "Pro",


### PR DESCRIPTION
Implementation of #9 

Created a `WithXXX` for every option, except for boolean values `async` which is `UseAsync()`

Something I see (and like in a lot of go libraries) is to not allow HTTP Client specific configs (such as `Timeout`), but rather just allow to specify the whole http client to use. This allows to also easily use other http clients, such as https://github.com/hashicorp/go-retryablehttp (I added an example of that to the readme as well)

default usage looks like this:

```go
client, err := vemetric.New("YOUR_PROJECT_TOKEN")
```

or, with configuration:

```go
client, err := vemetric.New(
    "YOUR_PROJECT_TOKEN",  // Required
    // Optional, defaults to https://hub.vemetric.com
    vemetric.WithHost("https://custom.host"),
    // Optional, defaults to a http.Client with a 3 second timeout
    vemetric.WithHTTPClient(&http.Client{Timeout: 3 * time.Second}),
    // Optional, defaults to false, configures if the requests should be fired asynchronously
    vemetric.UseAsync(),
    // Optional, defaults to 10
    vemetric.WithAsyncBufferedChannelSize(10),
})